### PR TITLE
Add stonkcomp command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,4 +9,5 @@ pub mod math;
 pub mod meta;
 pub mod owner;
 pub mod random;
+pub mod stonkcomp;
 pub mod stonks;

--- a/src/commands/stonkcomp.rs
+++ b/src/commands/stonkcomp.rs
@@ -4,7 +4,7 @@ use serenity::prelude::*;
 
 #[command]
 #[aliases("stockcomp", "stonkcomp", "s&pcomp")]
-async fn stonks(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+async fn stonkcomp(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     for stonk in args.iter::<String>() {
         let _ = msg
             .channel_id

--- a/src/commands/stonkcomp.rs
+++ b/src/commands/stonkcomp.rs
@@ -1,0 +1,21 @@
+use serenity::framework::standard::{macros::command, Args, CommandResult};
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+#[command]
+#[aliases("stockcomp", "stonkcomp", "s&pcomp")]
+async fn stonks(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+    for stonk in args.iter::<String>() {
+        let _ = msg
+            .channel_id
+            .say(
+                &ctx.http,
+                &format!(
+                    "https://stonks.egd.pw/spcomp?symbol={}",
+                    &stonk.unwrap()
+                ),
+            )
+            .await;
+    }
+    Ok(())
+}

--- a/src/commands/stonkcomp.rs
+++ b/src/commands/stonkcomp.rs
@@ -10,10 +10,7 @@ async fn stonks(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
             .channel_id
             .say(
                 &ctx.http,
-                &format!(
-                    "https://stonks.egd.pw/spcomp?symbol={}",
-                    &stonk.unwrap()
-                ),
+                &format!("https://stonks.egd.pw/spcomp?symbol={}", &stonk.unwrap()),
             )
             .await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,8 @@ impl EventHandler for Handler {
 // Remember to re-add advice here when its ready.
 #[group]
 #[commands(
-    ball, botsnack, describe, drink, about, add, multiply, ping, quit, github, random, food, stonks
+    ball, botsnack, describe, drink, about, add, multiply, ping, quit, github, random, food,
+    stonkcomp, stonks
 )]
 struct General;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use tracing::{info, instrument};
 // Re import advice::*,  when its ready
 use commands::{
     ball::*, botsnack::*, desc::*, drink::*, food::*, github::*, math::*, meta::*, owner::*,
-    random::*, stonks::*,
+    random::*, stonkcomp::*, stonks::*,
 };
 
 struct ShardManagerContainer;


### PR DESCRIPTION
Add the ~stonkcomp (or ~stockcomp or ~s&pcomp) command to the bot to provide the S&P comparison charts.
As cheap of a copy/paste job as I could muster.
Strictly, the endpoint can also take a "days" parameter, but I didn't feel like handling that case right now.
I've tested it exactly as much as you have.