### PR TITLE
migrations: make value not nullable

### DIFF
--- a/migrations/2021-04-14-224808_value_not_null/down.sql
+++ b/migrations/2021-04-14-224808_value_not_null/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE descriptions ALTER COLUMN value DROP NOT NULL;

--- a/migrations/2021-04-14-224808_value_not_null/up.sql
+++ b/migrations/2021-04-14-224808_value_not_null/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE descriptions ALTER COLUMN value SET NOT NULL;


### PR DESCRIPTION
Apparently the default in SQL is that a column is nullable unless you
include the `NOT NULL` constraint.