### PR TITLE
Use Discord's native slash-commands instead of plaintext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +596,15 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1383,6 +1398,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "env_logger",
+ "itertools",
  "lazy_static",
  "log",
  "maplit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "env_logger",
- "futures",
+ "lazy_static",
  "log",
  "maplit",
  "rand 0.8.4",
@@ -1391,9 +1391,30 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1383,9 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "env_logger",
+ "futures",
  "log",
+ "maplit",
  "rand 0.8.4",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ readme = "README.md"
 
 [dependencies]
 env_logger = "0.8.3"
-futures = { version = "0.3", default_features = false }
+lazy_static = "1.4"
 log = "0.4.14"
 maplit = "1.0"
 rand = "0.8.3"
 reqwest = { version = "0.11.1", features = ["blocking", "json"] }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.56"
+thiserror = "1.0"
 tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.25"
 dotenv = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [dependencies]
 env_logger = "0.8.3"
+itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"
 maplit = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ features = [
     "standard_framework",
     "utils",
     "rustls_backend",
+    "unstable_discord_api"
 ]
 version = "^0.10.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 
 [dependencies]
 env_logger = "0.8.3"
+futures = { version = "0.3", default_features = false }
 log = "0.4.14"
+maplit = "1.0"
 rand = "0.8.3"
 reqwest = { version = "0.11.1", features = ["blocking", "json"] }
 serde = { version = "1.0.115", features = ["derive"] }

--- a/src/commands/advice.rs
+++ b/src/commands/advice.rs
@@ -1,7 +1,9 @@
+use crate::SlashCommand;
+
 use serde::Deserialize;
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
 #[derive(Deserialize)]
 struct Slip {
@@ -14,14 +16,17 @@ struct Advice {
     slip: Slip,
 }
 
-#[command]
-#[description = "Asks for the advice of the gods and reveals their musings."]
-#[usage = ""]
-async fn advice(ctx: &Context, msg: &Message) -> CommandResult {
+async fn advice(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
     const ENDPOINT: &str = "https://api.adviceslip.com/advice";
     let advice = reqwest::get(ENDPOINT).await?.json::<Advice>().await?;
     let results = format!("{} - #{}", advice.slip.advice, advice.slip.id);
-
-    let _ = msg.channel_id.say(&ctx.http, results).await;
-    Ok(())
+    Ok(results)
 }
+
+make_slash_command_handler!(AdviceHandler, advice);
+
+pub(crate) static ADVICE_COMMAND: SlashCommand = SlashCommand {
+    description: "Asks for the advice of the gods and reveals their musings.",
+    handler: &AdviceHandler,
+    options: vec![],
+};

--- a/src/commands/ball.rs
+++ b/src/commands/ball.rs
@@ -1,13 +1,11 @@
-use rand::seq::SliceRandom;
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use crate::{SlashCommand, SlashCommandOption};
 
-#[command]
-#[aliases("8ball")]
-#[description = "Shakes the digital 8-ball."]
-#[usage = ""]
-async fn ball(ctx: &Context, msg: &Message) -> CommandResult {
+use rand::seq::SliceRandom;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
+
+async fn ball(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
     let responses = vec![
         "As I see it, yes.",
         "Ask again later.",
@@ -33,7 +31,21 @@ async fn ball(ctx: &Context, msg: &Message) -> CommandResult {
 
     let choice = responses.choose(&mut rand::thread_rng()).unwrap();
 
-    let _ = msg.channel_id.say(&ctx.http, choice).await;
+    Ok(choice.to_string())
+}
 
-    Ok(())
+make_slash_command_handler!(BallHandler, ball);
+
+lazy_static::lazy_static! {
+    pub(crate) static ref BALL_COMMAND: SlashCommand = SlashCommand {
+        description: "Shakes the digital 8-ball.",
+        handler: &BallHandler,
+        options: vec![
+            SlashCommandOption {
+                name: "question".to_string(),
+                required: true,
+                description: "What would you like to ask the magic 8-ball?".to_string(),
+            },
+        ]
+    };
 }

--- a/src/commands/botsnack.rs
+++ b/src/commands/botsnack.rs
@@ -1,15 +1,21 @@
-use futures::future::FutureExt;
+use crate::SlashCommand;
+
 use rand::seq::SliceRandom;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
 use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
-pub fn botsnack(
-    _: &ApplicationCommandInteractionData,
-) -> crate::BoxFuture<'static, Option<String>> {
-    async move {
-        let responses = vec!["Yum!", "*cronch*", "MOAR", "*Smiles*", "Nice."];
-        let response = *responses.choose(&mut rand::thread_rng()).unwrap();
+async fn botsnack(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
+    let responses = vec!["Yum!", "*cronch*", "MOAR", "*Smiles*", "Nice."];
+    let response = *responses.choose(&mut rand::thread_rng()).unwrap();
 
-        Some(response.to_owned())
-    }
-    .boxed()
+    Ok(response.to_owned())
 }
+
+make_slash_command_handler!(BotsnackHandler, botsnack);
+
+pub(crate) static BOTSNACK_COMMAND: SlashCommand = SlashCommand {
+    description: "A bot's gotta eat....",
+    handler: &BotsnackHandler,
+    options: vec![],
+};

--- a/src/commands/botsnack.rs
+++ b/src/commands/botsnack.rs
@@ -1,16 +1,12 @@
+use futures::future::FutureExt;
 use rand::seq::SliceRandom;
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
 
-#[command]
-#[description = "A bot's gotta eat...."]
-#[usage = ""]
-async fn botsnack(ctx: &Context, msg: &Message) -> CommandResult {
-    let responses = vec!["Yum!", "*cronch*", "MOAR", "*Smiles*", "Nice."];
-    let response = responses.choose(&mut rand::thread_rng()).unwrap();
+pub fn botsnack() -> crate::BoxFuture<'static, Option<String>> {
+    async move {
+        let responses = vec!["Yum!", "*cronch*", "MOAR", "*Smiles*", "Nice."];
+        let response = *responses.choose(&mut rand::thread_rng()).unwrap();
 
-    let _ = msg.channel_id.say(&ctx.http, response).await;
-
-    Ok(())
+        Some(response.to_owned())
+    }
+    .boxed()
 }

--- a/src/commands/botsnack.rs
+++ b/src/commands/botsnack.rs
@@ -1,7 +1,10 @@
 use futures::future::FutureExt;
 use rand::seq::SliceRandom;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
-pub fn botsnack() -> crate::BoxFuture<'static, Option<String>> {
+pub fn botsnack(
+    _: &ApplicationCommandInteractionData,
+) -> crate::BoxFuture<'static, Option<String>> {
     async move {
         let responses = vec!["Yum!", "*cronch*", "MOAR", "*Smiles*", "Nice."];
         let response = *responses.choose(&mut rand::thread_rng()).unwrap();

--- a/src/commands/desc.rs
+++ b/src/commands/desc.rs
@@ -10,12 +10,6 @@ use serenity::client::Context;
 use serenity::framework::standard::CommandResult;
 use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
-#[derive(thiserror::Error, Debug)]
-enum DescribeError {
-    #[error("One or more options is missing from the Discord API")]
-    OptionMissing,
-}
-
 // TODO: #[aliases("set")]
 async fn describe(ctx: &Context, input_key: &str, input_value: &str) -> CommandResult<String> {
     let data = ctx.data.read().await;
@@ -49,7 +43,7 @@ async fn handle_describe(
 
     match (arguments.get("key"), arguments.get("value")) {
         (Some(&input_key), Some(&input_value)) => describe(ctx, input_key, input_value).await,
-        _ => Err(Box::new(DescribeError::OptionMissing)),
+        _ => Err(Box::new(super::CommandError::OptionMissing)),
     }
 }
 
@@ -105,7 +99,7 @@ async fn handle_define(
 ) -> CommandResult<String> {
     match super::get_string_arguments(data).get("key") {
         Some(&input_key) => define(ctx, input_key).await,
-        None => Err(Box::new(DescribeError::OptionMissing)),
+        None => Err(Box::new(super::CommandError::OptionMissing)),
     }
 }
 

--- a/src/commands/desc.rs
+++ b/src/commands/desc.rs
@@ -4,30 +4,26 @@ use crate::diesel::RunQueryDsl;
 use crate::models::*;
 use crate::schema::descriptions::dsl::*;
 use crate::PostgresClient;
+use crate::{SlashCommand, SlashCommandOption};
 use diesel::r2d2::ManageConnection;
-use serenity::framework::standard::{macros::command, Args, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
-#[command]
-#[aliases("set")]
-async fn describe(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+#[derive(thiserror::Error, Debug)]
+enum DescribeError {
+    #[error("One or more options is missing from the Discord API")]
+    OptionMissing,
+}
+
+// TODO: #[aliases("set")]
+async fn describe(ctx: &Context, input_key: &str, input_value: &str) -> CommandResult<String> {
     let data = ctx.data.read().await;
-    let input_key = args.single::<String>().unwrap();
-    let input_value = args.remains().unwrap();
 
     if let Some(dbclient) = data.get::<PostgresClient>() {
         let connection = dbclient.connect().expect("Could not connect to Postgres");
-        let _ = msg
-            .channel_id
-            .say(
-                &ctx.http,
-                &format!("Defining {} as: '{}'", &input_key, &input_value),
-            )
-            .await;
-
         let description = NewDescription {
-            key: &input_key,
+            key: input_key,
             value: input_value,
         };
         diesel::insert_into(descriptions)
@@ -36,26 +32,51 @@ async fn describe(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
             .do_update()
             .set(&description)
             .execute(&connection)?;
+        Ok(format!("Defining {} as: '{}'", input_key, input_value))
     } else {
-        msg.reply(
-            ctx,
-            &format!(
-                "There was a problem reading from the databse. Failed to define {} as '{}'",
-                &input_key, &input_value
-            ),
-        )
-        .await?;
-
-        return Ok(());
-    };
-    Ok(())
+        Ok(format!(
+            "There was a problem reading from the databse. Failed to define {} as '{}'",
+            input_key, input_value
+        ))
+    }
 }
 
-#[command]
-#[aliases("show", "get")]
-async fn define(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+async fn handle_describe(
+    ctx: &Context,
+    data: &ApplicationCommandInteractionData,
+) -> CommandResult<String> {
+    let arguments = super::get_string_arguments(data);
+
+    match (arguments.get("key"), arguments.get("value")) {
+        (Some(&input_key), Some(&input_value)) => describe(ctx, input_key, input_value).await,
+        _ => Err(Box::new(DescribeError::OptionMissing)),
+    }
+}
+
+make_slash_command_handler!(DescribeHandler, handle_describe);
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DESCRIBE_COMMAND: SlashCommand = SlashCommand {
+        description: "Sets the stored definition for a word",
+        options: vec![
+            SlashCommandOption {
+                name: "key".to_string(),
+                description: "Key".to_string(),
+                required: true,
+            },
+            SlashCommandOption {
+                name: "value".to_string(),
+                description: "Its definition".to_string(),
+                required: true,
+            },
+        ],
+        handler: &DescribeHandler,
+    };
+}
+
+// TODO: #[aliases("show", "get")]
+async fn define(ctx: &Context, input_key: &str) -> CommandResult<String> {
     let data = ctx.data.read().await;
-    let input_key = args.single::<String>().unwrap();
 
     if let Some(dbclient) = data.get::<PostgresClient>() {
         let connection = dbclient.connect().expect("Could not connect to Postgres");
@@ -66,24 +87,40 @@ async fn define(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
             .load::<Description>(&connection)
             .expect("Error loading results.");
 
-        let _ = msg
-            .channel_id
-            .say(
-                &ctx.http,
-                &format!("{} is decribed as: '{}'", input_key, &value_data[0].value),
-            )
-            .await;
+        Ok(format!(
+            "{} is decribed as: '{}'",
+            input_key, &value_data[0].value
+        ))
     } else {
-        msg.reply(
-            ctx,
-            &format!(
-                "There was a problem looking up the value for {}",
-                &input_key
-            ),
-        )
-        .await?;
-
-        return Ok(());
+        Ok(format!(
+            "There was a problem looking up the value for {}",
+            &input_key
+        ))
     }
-    Ok(())
+}
+
+async fn handle_define(
+    ctx: &Context,
+    data: &ApplicationCommandInteractionData,
+) -> CommandResult<String> {
+    match super::get_string_arguments(data).get("key") {
+        Some(&input_key) => define(ctx, input_key).await,
+        None => Err(Box::new(DescribeError::OptionMissing)),
+    }
+}
+
+make_slash_command_handler!(DefineHandler, handle_define);
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFINE_COMMAND: SlashCommand = SlashCommand {
+        description: "Retrieves the stored definition for a word",
+        options: vec![
+            SlashCommandOption {
+                name: "key".to_string(),
+                description: "Key".to_string(),
+                required: true,
+            },
+        ],
+        handler: &DefineHandler,
+    };
 }

--- a/src/commands/drink.rs
+++ b/src/commands/drink.rs
@@ -1,13 +1,11 @@
-use rand::seq::SliceRandom;
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use crate::SlashCommand;
 
-#[command]
-#[aliases("drink", "drinks", "drank")]
-#[description = "Reply with a suggestion of fine beverage."]
-#[usage = ""]
-async fn drink(ctx: &Context, msg: &Message) -> CommandResult {
+use rand::seq::SliceRandom;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
+
+async fn drink(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
     let responses = vec![
         "Water.",
         "Topo Chico",
@@ -27,7 +25,13 @@ async fn drink(ctx: &Context, msg: &Message) -> CommandResult {
 
     let drink = responses.choose(&mut rand::thread_rng()).unwrap();
 
-    let _ = msg.channel_id.say(&ctx.http, drink).await;
-
-    Ok(())
+    Ok(drink.to_string())
 }
+
+make_slash_command_handler!(DrinkHandler, drink);
+
+pub(crate) static DRINK_COMMAND: SlashCommand = SlashCommand {
+    description: "Reply with a suggestion of fine beverage.",
+    handler: &DrinkHandler,
+    options: vec![],
+};

--- a/src/commands/food.rs
+++ b/src/commands/food.rs
@@ -1,13 +1,12 @@
-use rand::seq::SliceRandom;
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use crate::SlashCommand;
 
-#[command]
-#[aliases("cuisine", "dinner", "lunch", "breakfast", "snack")]
-#[description = "Reply with a suggestion for cuisine."]
-#[usage = ""]
-async fn food(ctx: &Context, msg: &Message) -> CommandResult {
+use rand::seq::SliceRandom;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
+
+// TODO: #[aliases("cuisine", "dinner", "lunch", "breakfast", "snack")]
+async fn food(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
     let responses = vec![
         "Asian", "Barbecue", "Burgers", "Italian", "Mexican", "Pho", "Pizza", "Steak", "Seafood",
         "Indian", "Cajun",
@@ -15,7 +14,13 @@ async fn food(ctx: &Context, msg: &Message) -> CommandResult {
 
     let item = responses.choose(&mut rand::thread_rng()).unwrap();
 
-    let _ = msg.channel_id.say(&ctx.http, item).await;
-
-    Ok(())
+    Ok(item.to_string())
 }
+
+make_slash_command_handler!(FoodHandler, food);
+
+pub(crate) static FOOD_COMMAND: SlashCommand = SlashCommand {
+    description: "Reply with a suggestion for cuisine.",
+    handler: &FoodHandler,
+    options: vec![],
+};

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -1,16 +1,18 @@
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use crate::SlashCommand;
 
-#[command]
-#[aliases("source")]
-#[description = "Reply with a link to the bot's source code"]
-#[usage = ""]
-async fn github(ctx: &Context, msg: &Message) -> CommandResult {
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
+
+async fn github(_: &Context, _: &ApplicationCommandInteractionData) -> CommandResult<String> {
     let github = "https://github.com/tmcarr/testbot";
-    let _ = msg
-        .channel_id
-        .say(&ctx.http, &format!("My code is at: {}", &github))
-        .await;
-    Ok(())
+    Ok(format!("My code is at: {}", &github))
 }
+
+make_slash_command_handler!(GithubHandler, github);
+
+pub(crate) static GITHUB_COMMAND: SlashCommand = SlashCommand {
+    description: "Reply with a link to the bot's source code",
+    handler: &GithubHandler,
+    options: vec![],
+};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,3 +9,19 @@ pub mod owner;
 pub mod pingpong;
 pub mod random;
 pub mod stonks;
+
+fn get_string_arguments(
+    data: &crate::ApplicationCommandInteractionData,
+) -> std::collections::HashMap<&str, &str> {
+    data.options
+        .iter()
+        // We should only ever get a JSON string from the Discord API, but if they don't uphold
+        // that, then we'll ignore the value completely.
+        .filter_map(|o| {
+            o.value
+                .as_ref()
+                .and_then(|v| v.as_str())
+                .map(|v| (o.name.as_str(), v))
+        })
+        .collect()
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,6 +30,12 @@ pub mod pingpong;
 pub mod random;
 pub mod stonks;
 
+#[derive(thiserror::Error, Debug)]
+enum CommandError {
+    #[error("One or more options is missing from the Discord API")]
+    OptionMissing,
+}
+
 fn get_string_arguments(
     data: &crate::ApplicationCommandInteractionData,
 ) -> std::collections::HashMap<&str, &str> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,23 @@
+// The make_slash_command_handler macro will be available to all of the child modules, thanks to the
+// historical "textual scope" that applies to macros.  #[macro_export] makes scoping rules more
+// normal, but forcefully makes the macro pub and that is even worse.
+macro_rules! make_slash_command_handler {
+    ($struct_name:ident, $function:ident) => {
+        struct $struct_name;
+
+        #[crate::async_trait]
+        impl crate::SlashCommandHandler for $struct_name {
+            async fn handle(
+                &self,
+                ctx: &$crate::Context,
+                data: &$crate::ApplicationCommandInteractionData,
+            ) -> CommandResult<String> {
+                $function(ctx, data).await
+            }
+        }
+    };
+}
+
 pub mod advice;
 pub mod ball;
 pub mod botsnack;

--- a/src/commands/pingpong.rs
+++ b/src/commands/pingpong.rs
@@ -1,24 +1,30 @@
-use serenity::framework::standard::{macros::command, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use crate::{async_trait, SlashCommand, SlashCommandHandler};
 
-#[command]
-#[description = "Reploy with 'Pong!'"]
-#[usage = ""]
-async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
-    let _ = msg.channel_id.say(&ctx.http, "Pong!").await;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
-    Ok(())
+struct StaticReplyHandler(&'static str);
+
+#[async_trait]
+impl SlashCommandHandler for StaticReplyHandler {
+    async fn handle(
+        &self,
+        _: &Context,
+        _: &ApplicationCommandInteractionData,
+    ) -> CommandResult<String> {
+        Ok(self.0.to_string())
+    }
 }
 
-#[command]
-#[description = "Let er' rip!"]
-#[usage = ""]
-async fn fart(ctx: &Context, msg: &Message) -> CommandResult {
-    let _ = msg
-        .channel_id
-        .say(&ctx.http, "Thbbbbbbbbbbbbbbt.... squeak.")
-        .await;
+pub(crate) static FART_COMMAND: SlashCommand = SlashCommand {
+    description: "Let er' rip!",
+    handler: &StaticReplyHandler("Thbbbbbbbbbbbbbbt.... squeak."),
+    options: vec![],
+};
 
-    Ok(())
-}
+pub(crate) static PING_COMMAND: SlashCommand = SlashCommand {
+    description: "Reploy with 'Pong!'",
+    handler: &StaticReplyHandler("Pong!"),
+    options: vec![],
+};

--- a/src/commands/random.rs
+++ b/src/commands/random.rs
@@ -1,21 +1,19 @@
-use rand::seq::SliceRandom;
-use serenity::framework::standard::{macros::command, Args, CommandResult};
-use serenity::model::prelude::*;
-use serenity::prelude::*;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use rand::seq::IteratorRandom;
+use serenity::model::prelude::application_command::*;
 
-#[command]
-#[aliases("rand")]
-#[description = "Choose a ranfrom item from the list of inputs"]
-#[usage = "foo bar baz"]
-async fn random(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-    let choices = args.raw().collect::<Vec<&str>>();
+// TODO: #[aliases("rand")]
 
-    let thing = choices.choose(&mut rand::thread_rng());
+pub fn handler(data: &ApplicationCommandInteractionData) -> BoxFuture<'static, Option<String>> {
+    let arguments = super::get_string_arguments(data);
 
-    match thing {
-        Some(choice) => msg.channel_id.say(&ctx.http, choice).await?,
-        _ => msg.channel_id.say(&ctx.http, "Why u no args?!").await?,
+    let thing = arguments.values().choose(&mut rand::thread_rng());
+
+    let response = match thing {
+        Some(&choice) => choice.to_owned(),
+        _ => "Why u no args?!".to_owned(),
     };
 
-    Ok(())
+    async move { Some(response) }.boxed()
 }

--- a/src/commands/random.rs
+++ b/src/commands/random.rs
@@ -1,11 +1,12 @@
-use futures::future::BoxFuture;
-use futures::FutureExt;
+use crate::{SlashCommand, SlashCommandOption};
+
 use rand::seq::IteratorRandom;
-use serenity::model::prelude::application_command::*;
+use serenity::client::Context;
+use serenity::framework::standard::CommandResult;
+use serenity::model::interactions::application_command::ApplicationCommandInteractionData;
 
 // TODO: #[aliases("rand")]
-
-pub fn handler(data: &ApplicationCommandInteractionData) -> BoxFuture<'static, Option<String>> {
+async fn random(_ctx: &Context, data: &ApplicationCommandInteractionData) -> CommandResult<String> {
     let arguments = super::get_string_arguments(data);
 
     let thing = arguments.values().choose(&mut rand::thread_rng());
@@ -15,5 +16,21 @@ pub fn handler(data: &ApplicationCommandInteractionData) -> BoxFuture<'static, O
         _ => "Why u no args?!".to_owned(),
     };
 
-    async move { Some(response) }.boxed()
+    Ok(response)
+}
+
+make_slash_command_handler!(RandomHandler, random);
+
+lazy_static::lazy_static! {
+    pub(crate) static ref RANDOM_COMMAND: SlashCommand = SlashCommand {
+        description: "Choose a random item from the list of inputs",
+        options: (1..=25)
+            .map(|i| SlashCommandOption {
+                name: format!("choice{}", i),
+                required: false,
+                description: format!("Choice {}", i),
+            })
+            .collect(),
+        handler: &RandomHandler,
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ impl TypeMapKey for PostgresClient {
     type Value = diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>;
 }
 
+#[derive(Clone)]
 struct SlashCommandOption {
     name: String,
     required: bool,
@@ -285,14 +286,18 @@ async fn main() {
         "8ball" => &*commands::ball::BALL_COMMAND,
         "advice" => &commands::advice::ADVICE_COMMAND,
         "botsnack" => &commands::botsnack::BOTSNACK_COMMAND,
+        "company" => &*commands::stonks::COMPANY_COMMAND,
         "cuisine" => &commands::food::FOOD_COMMAND,
         "define" => &*commands::desc::DEFINE_COMMAND,
         "describe" => &*commands::desc::DESCRIBE_COMMAND,
         "drink" => &commands::drink::DRINK_COMMAND,
         "fart" => &commands::pingpong::FART_COMMAND,
         "ping" => &commands::pingpong::PING_COMMAND,
+        "price" => &*commands::stonks::PRICE_COMMAND,
         "random" => &*commands::random::RANDOM_COMMAND,
         "source" => &commands::github::GITHUB_COMMAND,
+        "stonks" => &*commands::stonks::STONKS_COMMAND,
+        "stonkcomp" => &*commands::stonks::STONKCOMP_COMMAND,
     };
 
     // Create the framework

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use serenity::{
         interactions::application_command::{
             ApplicationCommandInteractionData, ApplicationCommandOptionType,
         },
-        interactions::Interaction,
+        interactions::{Interaction, InteractionResponseType},
         prelude::UserId,
     },
     prelude::*,
@@ -200,15 +200,23 @@ impl EventHandler for Handler {
             .handle(&ctx, &application_command.data)
             .await;
 
-        if let Ok(text) = response {
-            let api_response = application_command.create_interaction_response(ctx.http, |r| {
-                r.kind(serenity::model::interactions::InteractionResponseType::ChannelMessageWithSource)
-                .interaction_response_data(|message| message.content(text))
-            }).await;
+        match response {
+            Ok(text) => {
+                let api_response = application_command
+                    .create_interaction_response(ctx.http, |r| {
+                        r.kind(InteractionResponseType::ChannelMessageWithSource)
+                            .interaction_response_data(|message| message.content(text))
+                    })
+                    .await;
 
-            if let Err(e) = api_response {
-                error!("Error sending bot response: {:?}", e);
+                if let Err(e) = api_response {
+                    error!("Error sending bot response: {:?}", e);
+                }
             }
+            Err(e) => error!(
+                "Handler for command {} failed: {:?}",
+                application_command.data.name, e
+            ),
         }
     }
 


### PR DESCRIPTION
These commands show up in the Discord UI when you type a `/`, and give the user some assistance with their arguments to boot.  It's a little more annoying to use things like `/random` because of that, but I think the experience is better overall.

I'll apologize ahead of time, since this is a **lot** of code.  I would, though, like you to look through it and ask about anything that looks weird — I'll be more than happy to add comments and/or clarify.  Hopefully I didn't make too many mistakes when I did the bulk conversion on autopilot.

There's some design information in [the commit message of 4e84df90109e](https://github.com/tmcarr/testbot/commit/4e84df90109ed29d836f83ec3aa7df83a5daa8f1); if you want to squash-and-merge rather than a merge commit, let me write the squashed commit message since I'd like that design-alternatives to be preserved in the history.